### PR TITLE
[Dependency update] Bump axios version to 0.21.1 to fix vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test": "mocha --ui qunit --reporter list --timeout 10000 -- *.spec.js"
   },
   "dependencies": {
-    "axios": "0.19.0",
+    "axios": "0.21.1",
     "debug": "^3.0.1",
     "openurl": "^1.1.1",
     "yargs": "^13.3.0"


### PR DESCRIPTION
# Summary

Running `npm audit`, there's a high priority security vulnerability reported for `axios@<0.21.1`:

<img width="723" alt="Screen Shot 2021-01-06 at 2 29 30 AM" src="https://user-images.githubusercontent.com/9907610/103758753-7aaa4f00-4fc7-11eb-818b-93146df33883.png">

The change here just bumps `axios` to version `0.21.1`, in which the issue was patched.

_An [issue was opened](https://github.com/localtunnel/localtunnel/issues/377) for this in the main localtunnel repo recently, but it doesn't appear that the maintainers are active there anymore._